### PR TITLE
Open generated project in an IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Spring Initializr Changelog
 
+## [Allow to automatically unzip and open the IDE] - {PR_MERGE_DATE}
+- Allow to automatically unzip the downloaded archive
+- Allow to automatically open the project in your favorite IDE
+- Allow the user to configure : auto-unzip, open in IDE, favorite IDE
+
 ## [Initial Version] - {PR_MERGE_DATE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.88.3",
-        "@raycast/utils": "^1.17.0"
+        "@raycast/utils": "^1.17.0",
+        "adm-zip": "^0.5.16"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.11",
+        "@types/adm-zip": "^0.5.7",
         "@types/node": "20.8.10",
         "@types/node-fetch": "^2.6.12",
         "@types/react": "18.3.3",
@@ -1043,6 +1045,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
+      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1450,6 +1462,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -45,15 +45,42 @@
       "label": "Open Directory",
       "default": true,
       "required": false
+    },
+    {
+      "name": "unzip",
+      "description": "Do you want to automatically unzip the downloaded archive. If set to false the option to open in IDE will not work",
+      "title": "Unzip the downloaded archive",
+      "type": "checkbox",
+      "required": false,
+      "default": true,
+      "label": "Unzip automatically the archive"
+    },
+    {
+      "name": "openInIDE",
+      "description": "Do you want the extension to automatically open your project in your IDE. To use it you need to configure the IDE the extension needs to use",
+      "title": "Open in my IDE",
+      "type": "checkbox",
+      "required": false,
+      "default": false,
+      "label": "Open the project in my IDE"
+    },
+    {
+      "name": "ide",
+      "description": "The IDE you want to use to open your project",
+      "type": "appPicker",
+      "required": false,
+      "title": "Selected IDE"
     }
   ],
   "dependencies": {
     "@raycast/api": "^1.88.3",
-    "@raycast/utils": "^1.17.0"
+    "@raycast/utils": "^1.17.0",
+    "adm-zip": "^0.5.16"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.11",
     "@types/node": "20.8.10",
+    "@types/adm-zip": "^0.5.7",
     "@types/node-fetch": "^2.6.12",
     "@types/react": "18.3.3",
     "eslint": "^8.57.0",

--- a/src/spring-initializr.tsx
+++ b/src/spring-initializr.tsx
@@ -7,7 +7,8 @@ import {
   getPreferenceValues,
   popToRoot,
   open,
-  openCommandPreferences, Application
+  openCommandPreferences,
+  Application,
 } from "@raycast/api";
 import { useState, useEffect } from "react";
 import fetch from "node-fetch";
@@ -128,7 +129,7 @@ export default function Command() {
     fetchMetadata();
   }, []);
 
-  async function unzipFile(path:string, directory:string) {
+  async function unzipFile(path: string, directory: string) {
     try {
       const zip = new AdmZip(path);
       zip.extractAllTo(directory, true);
@@ -205,11 +206,11 @@ export default function Command() {
         message: `Saved to ${outputPath}`,
       });
 
-      if(preferences.unzip) {
-        const directory= path.join(outputDir, values.artifactId);
+      if (preferences.unzip) {
+        const directory = path.join(outputDir, values.artifactId);
         await unzipFile(outputPath, directory);
-        if(preferences.openInIDE && preferences.ide){
-          await openInIDE(directory,preferences.ide).catch( async () => {
+        if (preferences.openInIDE && preferences.ide) {
+          await openInIDE(directory, preferences.ide).catch(async () => {
             await showToast({
               style: Toast.Style.Failure,
               title: "An error occurred",
@@ -224,8 +225,6 @@ export default function Command() {
         const directoryToOpen = path.dirname(outputPath);
         await open(directoryToOpen);
       }
-
-
 
       // If user wants to pop to root after generation
       if (preferences.popToRootAfterGenerate) {


### PR DESCRIPTION
This PR introduces two new quality-of-life features to the Raycast extension for Spring Initializr:

	•	Automatic Archive Unzipping: Users now have the option to automatically unzip the downloaded project archive. This eliminates the manual step of extracting the project files, streamlining the initial project setup process.
	•	Open in Favorite IDE: Users can opt to have their downloaded project automatically opened in their favorite IDE. This provides a seamless transition from project download to development.